### PR TITLE
Fix lack of title when there's no files

### DIFF
--- a/UploadLocal.php
+++ b/UploadLocal.php
@@ -23,6 +23,8 @@ $wgExtensionCredits['specialpage'][] = array(
 	'path' => __FILE__,
 	'name' => 'UploadLocal',
 	'descriptionmsg' => 'uploadlocal-desc',
+	'url' => 'https://www.mediawiki.org/wiki/Extension:UploadLocal',
+	'version' => '1.1',
 );
 $wgSpecialPages['UploadLocal'] = 'UploadLocal';
 $wgMessagesDirs['UploadLocal'] = __DIR__ . '/i18n';

--- a/UploadLocalDirectory.php
+++ b/UploadLocalDirectory.php
@@ -14,6 +14,8 @@ class UploadLocalDirectory {
 	function execute() {
 		global $wgOut, $wgRequest, $wgUser, $wgEnableUploads,
 		  $wgUploadDirectory;
+		  
+		$wgOut->setPageTitle( wfMessage('specialuploadlocal') );
 		
 		// a bit of this is stolen from the SpecialUpload code, duplication
 		// is bad but there was no way to meaningfully integrate it into
@@ -62,9 +64,6 @@ class UploadLocalDirectory {
 	
 	function showForm() {
 		global $wgOut;
-		
-		$wgOut->setPageTitle( wfMessage('specialuploadlocal') );
-		
 		$wgOut->addWikitext( wfMessage( 'uploadlocaltext' )->text() );
 		
 		$titleObj = Title::makeTitle( NS_SPECIAL, 'UploadLocal' );


### PR DESCRIPTION
I fixed this issue from the extension page:
"If uploads are disabled, the page does not have a page title."

I also updated the extension credits to link to the [extension page](https://www.mediawiki.org/wiki/Extension:UploadLocal), and added a version number (1.1; pretty arbitrary since there's never been a version number before, but it isn't the initial version).
